### PR TITLE
Feedback filename change

### DIFF
--- a/_helm/sdx-deliver/Chart.yaml
+++ b/_helm/sdx-deliver/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.6.0
+appVersion: 1.7.0

--- a/app/meta_wrapper.py
+++ b/app/meta_wrapper.py
@@ -1,5 +1,4 @@
-import time
-
+from datetime import datetime
 from app.output_type import OutputType
 
 
@@ -48,10 +47,13 @@ class MetaWrapper:
         self._from_survey(survey_dict)
 
     def set_feedback(self, survey_dict: dict):
-        time_stamp = str(time.time()).split(".")[0]
-        self.filename = f'{self.filename}-fb-{time_stamp}:{locations["FTP"]}'
+        postfix = datetime.today().strftime('%H:%M:%S_%d-%m-%Y')
+        tx_id = self.filename
+        self.filename = f'{self.filename}-fb-{postfix}:{locations["FTP"]}'
         self.output_type = OutputType.FEEDBACK
         self._from_survey(survey_dict)
+        # reset the transaction id to the filename
+        self.tx_id = tx_id
 
     def set_comments(self):
         self.filename = f'{self.filename}:{locations["FTP"]}'

--- a/tests/test_meta_wrapper.py
+++ b/tests/test_meta_wrapper.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from app.meta_wrapper import MetaWrapper
 
@@ -80,16 +80,18 @@ class TestMetaWrapper(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(f'{filename}:hybrid', meta_data.filename)
 
-    @patch('app.meta_wrapper.time.time')
-    def test_set_feedback(self, mock_time):
-        mock_time.return_value = 1629452867.587326
+    @patch('app.meta_wrapper.datetime')
+    def test_set_feedback(self, mock_datetime):
+        mock_today = Mock()
+        mock_today.strftime.return_value = '15:47:27_05-09-2022'
+        mock_datetime.today.return_value = mock_today
         filename = "c37a3efa-593c-4bab-b49c-bee0613c4fb2"
         expected = "009 feedback response for period 2019 sample unit 49900108249D"
         meta_data = MetaWrapper(filename)
         meta_data.set_feedback(self.test_survey)
         actual = meta_data.get_description()
         self.assertEqual(expected, actual)
-        self.assertEqual(f'{filename}-fb-1629452867:ftp', meta_data.filename)
+        self.assertEqual(f'{filename}-fb-15:47:27_05-09-2022:ftp', meta_data.filename)
 
     def test_set_comments(self):
         filename = "c37a3efa-593c-4bab-b49c-bee0613c4fb2"


### PR DESCRIPTION
Updates the filename for feedback to use a formatted date/timestamp.
Ensure the correct tx_id is used for feedback (not the tx_id in the payload)