### PR TITLE
Change output mapper config so that ITIS move directly to downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ lint:
 .PHONY: dev
 dev:
 	@echo "Starting development server..."
+	gcloud auth application-default login
 	uv run run.py
 
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ lint:
 .PHONY: dev
 dev:
 	@echo "Starting development server..."
-	gcloud auth application-default login
 	uv run run.py
 
 

--- a/app/services/output_mapper/output_mapper_configs.py
+++ b/app/services/output_mapper/output_mapper_configs.py
@@ -8,12 +8,12 @@ DEFAULT_KEY: Final[str] = "default"
 
 SEFTOutputConfigProd: dict[str, File] = {
     "057": {
-        "location": LookupKey.FTP,
-        "path": "SDX_Prod/EDC_Submissions/057"
+        "location": LookupKey.NS3,
+        "path": "OF1/ITIS/ITIS_SDB/Submissions"
     },
     "058": {
-        "location": LookupKey.FTP,
-        "path": "SDX_Prod/EDC_Submissions/058"
+        "location": LookupKey.NS3,
+        "path": "OF1/ITIS/ITIS_SDB/Submissions"
     },
     "062": {
         "location": LookupKey.FTP,
@@ -71,12 +71,12 @@ SEFTOutputConfigProd: dict[str, File] = {
 
 SEFTOutputConfigPreProd: dict[str, File] = {
     "057": {
-        "location": LookupKey.FTP,
-        "path": "SDX_PREPROD/EDC_Submissions/057"
+        "location": LookupKey.NS3,
+        "path": "OF1/UAT Submissions"
     },
     "058": {
-        "location": LookupKey.FTP,
-        "path": "SDX_PREPROD/EDC_Submissions/058"
+        "location": LookupKey.NS3,
+        "path": "OF1/UAT Submissions"
     },
     "062": {
         "location": LookupKey.FTP,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdx-deliver"
-version = "4.0.13"
+version = "4.0.14"
 description = "Delivering for SDX"
 requires-python = "==3.13.*"
 dependencies = [

--- a/tests/integration/test_seft.py
+++ b/tests/integration/test_seft.py
@@ -67,8 +67,8 @@ class TestSeft(TestBase):
                     "outputs": [
                         {
                             "location_type": "windows_server",
-                            "location_name": "nifi-location-ftp",
-                            "path": "SDX_PREPROD/EDC_Submissions/057",
+                            "location_name": "nifi-location-ns3",
+                            "path": "OF1/UAT Submissions",
                             "filename": output_filename
                         }
                     ]

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "sdx-deliver"
-version = "4.0.13"
+version = "4.0.14"
 source = { virtual = "." }
 dependencies = [
     { name = "google-crc32c" },


### PR DESCRIPTION
This is a work to bypass Data Capture for the remaining SEFT (ITIS) since NiFi has completed the work to map to nsdata3